### PR TITLE
perldoc package namespace incorrect

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,5 +1,6 @@
 class smokeping::install {
-
+    include smokeping::params
+    
     package { 'smokeping':
         ensure => $smokeping::version
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,8 +7,8 @@ class smokeping::install {
     if ! defined (Package['fping']) {
         package {'fping': ensure => installed; }
     }
-    if ! defined (Package[$smokeping::package_perldoc]) {
-        package {$smokeping::package_perldoc: ensure => installed; }
+    if ! defined (Package[$smokeping::params::package_perldoc]) {
+        package {$smokeping::params::package_perldoc: ensure => installed; }
     }
 
     # correct permissions


### PR DESCRIPTION
Hi! Our puppet run was failing trying to install package `undef`, it seems there is now a little bit of confusion as to where the parameters should be coming from, init.pp or params.pp. For now this is unblocking us.

Thanks for the effort and cheers from @darktim
